### PR TITLE
Add bash completion for rbfu command

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -36,10 +36,11 @@ fi
 
 # bash completion
 #
+cat <<EOD
 _rbfu() {
-  cur="${COMP_WORDS[COMP_CWORD]}"
-  opts=$(ls $HOME/.rbfu/rubies)
-  COMPREPLY=( $(compgen -W "${opts} system" -- ${cur}) )
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  opts=\$(ls $HOME/.rbfu/rubies)
+  COMPREPLY=( \$(compgen -W "\${opts} system" -- \${cur}) )
 }
 complete -o nospace -F _rbfu rbfu
-
+EOD

--- a/init.sh
+++ b/init.sh
@@ -33,3 +33,13 @@ function cd() {
 }
 EOD
 fi
+
+# bash completion
+#
+_rbfu() {
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  opts=$(ls $HOME/.rbfu/rubies)
+  COMPREPLY=( $(compgen -W "${opts} system" -- ${cur}) )
+}
+complete -o nospace -F _rbfu rbfu
+


### PR DESCRIPTION
Let's add bash completion to this nice tool!
It will offer the currently installed rubies and the system ruby.

Example:

$ rbfu [TAB]
1.9.3-p0     jruby-1.6.5  system 

Hope you like it :)
