### PR TITLE
Hide rbfu_activate from shell TAB completion

### DIFF
--- a/bin/rbfu
+++ b/bin/rbfu
@@ -24,7 +24,7 @@ deactivate_previous_ruby_version () {
   fi
 }
 
-rbfu_activate () {
+_rbfu_activate () {
   local VERSION COMMAND MSG SOURCE
   local RBFU_ROOT="$HOME/.rbfu"
   local RUBIES_ROOT="$RBFU_ROOT/rubies"
@@ -143,5 +143,5 @@ EOD
 # normal operation
 #
 else
-  rbfu_activate $@
+  _rbfu_activate $@
 fi


### PR DESCRIPTION
Unless I'm confused `rbfu_activate` is meant to be an internal function, not
called directly by users. But given its name if I enter `rb[TAB]`, I get this:

```
    telemachus ~$ rb
    rbfu          ...-env       ..._activate
```

The change here hides the function away as _rbfu_activate.

Either way, thanks for this simple Ruby version manager.
