### PR TITLE
Add a usage message

### DIFF
--- a/bin/rbfu
+++ b/bin/rbfu
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Our usage message
+#/ rbfu[-env] usage:
+#/
+#/ rbfu @1.8.7 ruby -v  # Executes command using Ruby 1.8.7
+#/ rbfu ruby -v         # Executes command using Ruby specified in .ruby-version
+#/ rbfu-env @1.8.7      # Modifies current environment to use Ruby 1.8.7
+#/ rbfu-env             # Same as above, but reads Ruby version from .ruby-version
+
 # Useful methods. \o/
 #
 set_variable () { export $1="$2"; }
@@ -13,6 +21,9 @@ command_exists () { type "$1" &> /dev/null; }
 
 warn () { echo -e "$1" >&2; }
 info () { warn "$1"; }
+# Credit to rtomayko for this usage technique:
+# https://github.com/rtomayko/shocco/blob/master/shocco.sh#L35-57
+usage () { warn "$(grep '^#/' < "$0" | cut -c4-)"; }
 
 deactivate_previous_ruby_version () {
   if [ $RBFU_RUBY_VERSION ]; then
@@ -46,7 +57,7 @@ _rbfu_activate () {
   [ -n "$VERSION" ] || read_version_from_file "$HOME/.ruby-version"
 
   # sanity checks
-  [ ! "$VERSION" ] && warn "Please specify the Ruby version to activate." && return
+  [ ! "$VERSION" ] && usage && return
 
   if [[ "$VERSION" == "system" ]]; then
     deactivate_previous_ruby_version


### PR DESCRIPTION
This may seem like overkill to you, but I'll explain why I think it's worthwhile.

You lay out in the README the two basic ways to use `rbfu` - namely `rbfu` or `rbfu-env`, and you explain that each of those two commands can omit the Ruby version if there's a `.ruby-version` file present.

However, if the user calls simply `rbfu`, the error message is too brief and doesn't really cover the different ways to invoke and use `rbfu`.

I hope the current change gives a simple usage message without adding too much overhead. Thanks for considering it.
