### PR TITLE
Slightly fuller usage message

### DIFF
--- a/bin/rbfu
+++ b/bin/rbfu
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Our usage message
+#/ rbfu[-env] usage:
+#/
+#/ rbfu @1.8.7 ruby -v  # Executes command using Ruby 1.8.7
+#/ rbfu ruby -v         # Executes command using Ruby specified in .ruby-version
+#/ rbfu-env @1.8.7      # Modifies current environment to use Ruby 1.8.7
+#/ rbfu-env             # Same as above, but reads Ruby version from .ruby-version
+
 # Useful methods. \o/
 #
 set_variable () { export $1="$2"; }
@@ -13,6 +21,9 @@ command_exists () { type "$1" &> /dev/null; }
 
 warn () { echo -e "$1" >&2; }
 info () { warn "$1"; }
+# Credit to rtomayko for this usage technique:
+# https://github.com/rtomayko/shocco/blob/master/shocco.sh#L35-57
+usage () { warn "$(grep '^#/' < "$0" | cut -c4-)"; }
 
 deactivate_previous_ruby_version () {
   if [ $RBFU_RUBY_VERSION ]; then
@@ -46,7 +57,7 @@ _rbfu_activate () {
   [ -n "$VERSION" ] || read_version_from_file "$HOME/.ruby-version"
 
   # sanity checks
-  [ ! "$VERSION" ] && warn "Please specify the Ruby version to activate." && return
+  [ ! "$VERSION" ] && usage && return
 
   if [[ "$VERSION" == "system" ]]; then
     deactivate_previous_ruby_version
@@ -83,9 +94,7 @@ _rbfu_activate () {
 # check for our favorite command line options!
 #
 if [ "$1" = "--help" ]; then
-  cat <<EOD
-rbfu [@<version>] [command]
-EOD
+  usage
   exit 0
 
 # initialization code (run from shell startup script)


### PR DESCRIPTION
You may think this is overkill, but I find the `--help` message and the error given if there's no `$VERSION` found to be too brief.

This is an attempt to add a slightly fuller error and `--help` message without too much overhead. (Your `README` gives good examples of how to use `rbfu`. This patch simply pulls those into `rbfu` itself, so the user doesn't need to refer to the `README` if they're confused at the command line.)
